### PR TITLE
Fixed snapscroll and slide navigation bar bug

### DIFF
--- a/v2/preview.js
+++ b/v2/preview.js
@@ -85,9 +85,12 @@ function highlightCurrentSlide() {
                     if(thumbnails[index]){
                         thumbnails[index].classList.add('highlight');
                         thumbnails[index].scrollIntoView();
-                        if (index != slides.length - 1){
-                            previewSlider.scrollTop -= 20;
-                        }
+                        setTimeout(() => {
+                            thumbnails[index].scrollIntoView();
+                            if (index != slides.length - 1){
+                                previewSlider.scrollTop -= 20;
+                            }
+                        }, 50);
                     }
                 } else {
                     if(thumbnails[index]){


### PR DESCRIPTION
Added a timeout before scrolling the slide navigation bar to allow snapscroll to finish first.

closes #22 